### PR TITLE
Command line options, ./resources/application.properties, and adjustments to pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,13 @@
 		<url>https://github.com/ktllo/inviteBot</url>
 	</scm>
 
+	<repositories>
+		<repository>
+			<id>ivartj</id>
+			<url>http://maven.ivartj.org/</url>
+		</repository>
+	</repositories>
+
 	<build>
 		<sourceDirectory>${project.basedir}/src</sourceDirectory>
 		<outputDirectory>${project.basedir}/bin</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -145,10 +145,7 @@
 		<dependency>
 			<groupId>org.ivartj.args</groupId>
 			<artifactId>args</artifactId>
-
-			<!-- TODO: Get a proper version -->
-			<version>1.0-SNAPSHOT</version>
-
+			<version>1.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,17 @@
 	</scm>
 
 	<build>
-		<sourceDirectory>src</sourceDirectory>
-		<outputDirectory>bin</outputDirectory>
-		<testSourceDirectory>test/src</testSourceDirectory>
-		<testOutputDirectory>test/bin</testOutputDirectory>
+		<sourceDirectory>${project.basedir}/src</sourceDirectory>
+		<outputDirectory>${project.basedir}/bin</outputDirectory>
+		<testSourceDirectory>${project.basedir}/test/src</testSourceDirectory>
+		<testOutputDirectory>${project.basedir}/test/bin</testOutputDirectory>
+
+		<resources>
+			<resource>
+				<filtering>true</filtering>
+				<directory>${project.basedir}/resources</directory>
+			</resource>
+		</resources>
 
 		<plugins>
 
@@ -125,6 +132,16 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
 			<version>2.2</version>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.ivartj.args</groupId>
+			<artifactId>args</artifactId>
+
+			<!-- TODO: Get a proper version -->
+			<version>1.0-SNAPSHOT</version>
+
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/resources/application.properties
+++ b/resources/application.properties
@@ -1,0 +1,2 @@
+application.version=${pom.version}
+application.name=${pom.name}


### PR DESCRIPTION
Implemented -h, --help and --version command-line options using personally made argument processing library (https://github.com/ivartj/args-java).

Made ./resources/application.properties as a template for a file included in JAR. At build-time, it will have the current project name and version inserted into it, which can then be read from Java code. This way the name and version only has to be written in pom.xml.

pom.xml has been adjusted so that:
- Library is downloaded from my personal Maven repository (http://maven.ivartj.org/ -- there's no web page at the moment)
- ./resources/application.properties is included in the JAR.
- Minor adjustments.
