### PR TITLE
Refactor of Console.java

### DIFF
--- a/src/org/leolo/ircbot/inviteBot/Console.java
+++ b/src/org/leolo/ircbot/inviteBot/Console.java
@@ -100,6 +100,7 @@ public class Console extends ListenerAdapter<PircBotX> {
 		new MooCommand(),
 		new VersionCommand(),
 		new PingCommand(),
+		new PongCommand(),
 		new InviteCommand(),
 		new NickCommand(),
 		new InfoCommand(),
@@ -232,6 +233,16 @@ public class Console extends ListenerAdapter<PircBotX> {
 		@Override
 		public void main(CommandContext ctx, String args[]) {
 			ctx.out.print("pong");
+		}
+	}
+
+	private class PongCommand extends Command {
+
+		PongCommand() { super("pong", false); }
+
+		@Override
+		public void main(CommandContext ctx, String args[]) {
+			ctx.out.print("ping");
 		}
 	}
 

--- a/src/org/leolo/ircbot/inviteBot/Console.java
+++ b/src/org/leolo/ircbot/inviteBot/Console.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import org.leolo.ircbot.inviteBot.Config.Channel;
 import org.leolo.ircbot.inviteBot.util.Color;
 import org.leolo.ircbot.inviteBot.util.ColorName;
+import org.leolo.ircbot.inviteBot.util.UserUtil;
 import org.pircbotx.PircBotX;
 import org.pircbotx.User;
 import org.pircbotx.hooks.*;
@@ -81,7 +82,8 @@ public class Console extends ListenerAdapter<PircBotX> {
 		if(msg.length()==0 && config.isGlobalAdmin(event.getUser())){
 			msg = processMessage(event.getMessage(),
 					event.getUser(),
-					event.getBot());
+					event.getBot(),
+					"");
 		}
 		if(msg.length()>0){
 			String [] lines = msg.split("\n");
@@ -91,121 +93,272 @@ public class Console extends ListenerAdapter<PircBotX> {
 		}
 	}
 
+	private Command[] cmds = {
+		new MooCommand(),
+		new VersionCommand(),
+		new PingCommand(),
+		new InviteCommand(),
+		new NickCommand(),
+		new InfoCommand(),
+		new ResendCommand(),
+		new HelpCommand(),
+		new EchoCommand(),
+		new BackupCommand(),
+		new WhoamiCommand(),
 
-	
+		new AddAdminCommand(),
+		new RemoveAdminCommand(),
+		new ListAdminCommand(),
+		new AddExemptCommand(),
+		new RemoveExemptCommand(),
+		new ListExemptCommand(),
+	};
+
 	private String processMessage(String message,User user,PircBotX bot,String source){
-		String rmessage = message;
-		message = message.toLowerCase();
-		logger.debug(USAGE,"Reveived message {} from {}!{}@{}",message,user.getNick(),user.getLogin(),user.getHostmask());
-		if(message.startsWith("ping")){
+		CommandContext ctx = new CommandContext(user, bot, source);
+
+		String args[] = message.split(" +");
+		if(args.length == 0)
+			return "";
+
+		String cmdName = args[0].toLowerCase();
+
+		for(int i = 0; i < cmds.length; i++)
+			if(cmds[i].toString().toLowerCase().equals(cmdName)) {
+				if(cmds[i].requiresGlobalAdmin() && !config.isGlobalAdmin(ctx.user))
+					return Color.color(ColorName.RED)+"ERROR: UNAUTHORIZED";
+						
+				return cmds[i].run(ctx, args);
+			}
+
+		return Color.color(ColorName.RED) + "ERROR: UNRECOGNIZED COMMAND '" + cmdName + "'";
+	}
+
+	private static class CommandContext {
+		User user;
+		PircBotX bot;
+		String source;
+
+		CommandContext(User user, PircBotX bot, String source) {
+			this.user = user;
+			this.bot = bot;
+			this.source = source;
+		}
+	}
+	
+	private static abstract class Command {
+		String name;
+		boolean adminRequired;
+
+		Command(String name, boolean adminRequired) {
+			this.name = name;
+			this.adminRequired = adminRequired;
+		}
+
+		public abstract String run(CommandContext ctx, String args[]);
+
+		public String toString() {
+			return name;
+		}
+
+		public boolean requiresGlobalAdmin() {
+			return adminRequired;
+		}
+	}
+
+	private class MooCommand extends Command {
+
+		MooCommand() { super("moo", false); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			return "mooo";
+		}
+	}
+
+	private class VersionCommand extends Command {
+
+		VersionCommand() { super("version", false); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			return InviteBot.getName() + " version " + InviteBot.getVersion();
+		}
+	}
+
+	private class PingCommand extends Command {
+
+		PingCommand() { super("ping", false); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
 			return "pong";
-		}else if(message.startsWith("invite")){
-			logger.info(USAGE,user.getNick()+" inviting others");
-			String [] list = message.split(" ");
-			for(int i=1;i<list.length;i++){
+		}
+	}
+
+	private class InviteCommand extends Command {
+		
+		InviteCommand() { super("invite", false); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			logger.info(USAGE,ctx.user.getNick()+" inviting others");
+			for(int i=1;i<args.length;i++){
 				try{
-					int count = inviter.invite(list[i], bot.sendIRC(), user, source);
-					logger.info(USAGE,"Invited {} to {} channels",list[i],""+count);
+					int count = inviter.invite(args[i], ctx.bot.sendIRC(), ctx.user, ctx.source);
+					logger.info(USAGE,"Invited {} to {} channels",args[i],""+count);
 				}catch(UnauthorizedOperationException uoe){
 					logger.warn("User {} attempted to invite {} but he/she wasn't "
 							+ "authroized to do so.");
 				}
 			}
-		}else if(message.startsWith("info")){
-			if(config.isAdmin(user)){
-				long uptime = System.currentTimeMillis() - inviter.START;
-				int upD = (int)(uptime/86400000);
-				int upH = ((int)(uptime/3600000))%24;
-				int upM = ((int)(uptime/60000))%60;
-				int upS = ((int)(uptime/1000))%60;
-				StringBuilder sb = new StringBuilder();
-				sb.append("Inviter size is "+inviter.pendingItems.size()+"\n");
-				sb.append("Uptime is ");
-				if( uptime > 86400000 )
-					sb.append(upD).append(" days ");
-				if( uptime > 3600000 )
-					sb.append(upH).append(" hours ");
-				if( uptime > 60000 )
-					sb.append(upM).append(" minutes ");
-				if( uptime > 1000 )
-					sb.append(upS).append(" seconds ");
-				
-				return sb.toString();
-			}
-		}else if(message.startsWith("version")){
-			return InviteBot.getName() + " version " + InviteBot.getVersion();
-		}else if(message.startsWith("resend")){
+			return "";
+		}
+	}
+
+	private class InfoCommand extends Command {
+
+		InfoCommand() { super("info", true); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			long uptime = System.currentTimeMillis() - inviter.START;
+			int upD = (int)(uptime/86400000);
+			int upH = ((int)(uptime/3600000))%24;
+			int upM = ((int)(uptime/60000))%60;
+			int upS = ((int)(uptime/1000))%60;
+			StringBuilder sb = new StringBuilder();
+			sb.append("Inviter size is "+inviter.pendingItems.size()+"\n");
+			sb.append("Uptime is ");
+			if( uptime > 86400000 )
+				sb.append(upD).append(" days ");
+			if( uptime > 3600000 )
+				sb.append(upH).append(" hours ");
+			if( uptime > 60000 )
+				sb.append(upM).append(" minutes ");
+			if( uptime > 1000 )
+				sb.append(upS).append(" seconds ");
+			
+			return sb.toString();
+		}
+	}
+
+	private class ResendCommand extends Command {
+
+		ResendCommand() { super("resend", false); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
 			for(JoinRecord record:inviter.pendingItems){
-				if(record.getNick().equalsIgnoreCase(user.getNick())){
+				if(record.getNick().equalsIgnoreCase(ctx.user.getNick())){
 					return record.getQuestion().getQuestion();
 				}
 			}
 			return "Record not found. Please part and rejoin.";
-		}else if(message.startsWith("help")){
-			String [] cmd = message.split(" ");
-			if(cmd.length == 1){
+		}
+	}
+
+	private class HelpCommand extends Command {
+
+		HelpCommand() { super("help", false); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			if(args.length == 1){
 				return "Available command: ping, invite, info, version, resend, nick";
-			}else if(cmd[1].equalsIgnoreCase("ping")){
+			}else if(args[1].equalsIgnoreCase("ping")){
 				return "Check is the bot alive. No parametres";
-			}else if(cmd[1].equalsIgnoreCase("invite")){
+			}else if(args[1].equalsIgnoreCase("invite")){
 				StringBuilder sb = new StringBuilder();
 				sb.append(Color.color(ColorName.RED));
 				sb.append("ADMIN ONLY. ").append(Color.defaultColor());
 				sb.append("Invite user in holding channel without requiring them to answer the question\n");
 				sb.append("Parametres: List of nicks going to invite, sperated by space");
 				return sb.toString();
-			}else if(cmd[1].equalsIgnoreCase("info")){
+			}else if(args[1].equalsIgnoreCase("info")){
 				return "Report uptime and the number of entry in the inviter";
-			}else if(cmd[1].equalsIgnoreCase("version")){
+			}else if(args[1].equalsIgnoreCase("version")){
 				return "Version of the bot";
-			}else if(cmd[1].equalsIgnoreCase("resend")){
+			}else if(args[1].equalsIgnoreCase("resend")){
 				StringBuilder sb = new StringBuilder();
 				sb.append(Color.color(ColorName.DARK_BLUE));
 				sb.append("Should use in holding channel OR PM only. ").append(Color.defaultColor());
 				sb.append("Send the question for the requesting user as message in channel, if used in channel.\n");
 				sb.append("Send in PM if the command is sent via PM");
 				return sb.toString();
-			}else if(cmd[1].equalsIgnoreCase("nick")){
+			}else if(args[1].equalsIgnoreCase("nick")){
 				StringBuilder sb = new StringBuilder();
 				sb.append(Color.color(ColorName.RED));
 				sb.append("Global admin only ").append(Color.defaultColor());
 				sb.append("Change the bot's nickname to the nockname given\n");
 				return sb.toString();
-			}else if(cmd[1].equalsIgnoreCase("whoami")){
+			}else if(args[1].equalsIgnoreCase("whoami")){
 				return "Checks is the bot reconize you";
 			}
-		}else if(message.startsWith("nick")){
-			String [] cmd = rmessage.split(" ");
-			if(cmd.length == 1){
+			return "";
+		}
+	}
+
+	private class NickCommand extends Command {
+
+		NickCommand() { super("nick", true); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			if(args.length == 1){
 				return Color.color(ColorName.RED)+"ERROR: NICKNAME REQUIRED";
 			}
-			if(config.isGlobalAdmin(user)){
-				bot.sendIRC().changeNick(cmd[1]);
-				try {
-					Thread.sleep(2500);
-				} catch (InterruptedException e) {
-					e.printStackTrace();
-				}
-				if(!bot.getNick().equals(cmd[1])){
-					return Color.color(ColorName.RED)+"ERROR: Nick change failed";
-				}
-			}else{
-				logger.warn(USAGE, "User {}!{}@{} tried to change bot's nick but unauthorized", user.getNick(),user.getLogin(),user.getHostmask());
-				return Color.color(ColorName.RED)+"ERROR: UNAUTHORIZED";
+			ctx.bot.sendIRC().changeNick(args[1]);
+			try {
+				Thread.sleep(2500);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
 			}
-		}else if(message.startsWith("backup")){
-			if(config.isGlobalAdmin(user)){
-				return "backup as "+config.writeBackup();
+			if(!ctx.bot.getNick().equals(args[1])){
+				return Color.color(ColorName.RED)+"ERROR: Nick change failed";
 			}
-		}else if(message.startsWith("moo")){
-			return "moooo";
-		}else if(message.startsWith("whoami")){
-			if(config.isGlobalAdmin(user)){
+			return "";
+		}
+	}
+
+	private class EchoCommand extends Command {
+
+		EchoCommand() { super("echo", false); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			StringBuilder sb = new StringBuilder();
+			for(int i = 1; i < args.length; i++) {
+				sb.append(args[i]);
+				if(i + 1 != args.length)
+					sb.append(" ");
+			}
+			return sb.toString();
+		}
+	}
+
+	private class BackupCommand extends Command {
+
+		BackupCommand() { super("backup", true); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			return "backup as "+config.writeBackup();
+		}
+	}
+
+	private class WhoamiCommand extends Command {
+
+		WhoamiCommand() { super("whoami", false); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			if(config.isGlobalAdmin(ctx.user)){
 				return "Global Admin";
 			}
 			ArrayList<String> ch = new ArrayList<>();
 			for(Channel c : config.getChannels()){
-				if(c.isAdmin(user)){
+				if(c.isAdmin(ctx.user)){
 					ch.add(c.getChannelName());
 				}
 			}
@@ -223,107 +376,170 @@ public class Console extends ListenerAdapter<PircBotX> {
 			}
 			return "I don't reconize you";
 		}
-		return "";
 	}
-	
-	private String processMessage(String message,User user,PircBotX bot){
-		if(config.isGlobalAdmin(user)){
-			String lmsg = message.toLowerCase();
-			String [] args = lmsg.split(" ");
-			String rmsg = null;
-			if(args[0].equals("addadmin") || args[0].equals("removeadmin") ||
-					args[0].equals("listadmin") || args[0].equals("listexempt") ||
-					args[0].equals("addexempt") || args[0].equals("removeexempt"))
-			if(
-					((args[0].equals("addadmin") || args[0].equals("removeadmin") ||
-					args[0].equals("addexempt") || args[0].equals("removeexempt"))
-					&& args.length != 3 ) || 
-					(
-							(args[0].equals("listadmin") || args[0].equals("listexempt")) &&
-							args.length != 2
-					)){
-				return Color.color(ColorName.RED)+"ERROR: INCORRECT NUMBER OF PARAMETRE";
+
+	private class AddAdminCommand extends Command {
+
+		AddAdminCommand() { super("addadmin", true); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			String resp = "";
+
+			if(args.length != 3)
+				return Color.color(ColorName.RED)+"ERROR: INCORRECT NUMBER OF PARAMETRES";
+
+			String user = args[2];
+			String channel = args[1];
+
+			for(Channel c:config.getChannels()){
+				if(channel.equals(c.getKey())){
+					c.addAdmin(user);
+					logger.info(USAGE,"{} added to admin list of {} by {}",
+							user,channel,UserUtil.getUserHostmask(ctx.user));
+					resp = user + " added to admin list";
+				}
 			}
-			String backupName = config.writeBackup();
-			switch(args[0]){
-			case "addadmin":
-				for(Channel c:config.getChannels()){
-					if(args[1].equals(c.getKey())){
-						c.addAdmin(args[2]);
-						logger.info(USAGE,"{} added to admin list of {} by {}!{}@{} ",
-								args[2],args[1],user.getNick(),user.getLogin(),user.getHostmask());
-						rmsg = args[2] + " added to admin list";
-					}
-				}
-				break;
-			case "removeadmin":
-				for(Channel c:config.getChannels()){
-					if(args[1].equals(c.getKey())){
-						c.removeAdmin(args[2]);
-						logger.info(USAGE,"{} removed from admin list of {} by {}!{}@{} ",
-								args[2],args[1],user.getNick(),user.getLogin(),user.getHostmask());
-						rmsg = args[2] + " removed from admin list";
-					}
-				}
-				break;
-			case "addexempt":
-				for(Channel c:config.getChannels()){
-					if(args[1].equals(c.getKey())){
-						c.addExempt(args[2]);
-						logger.info(USAGE,"{} added to exempt list of {} by {}!{}@{} ",
-								args[2],args[1],user.getNick(),user.getLogin(),user.getHostmask());
-						rmsg = args[2] + " added to exempt list";
-					}
-				}
-				break;
-			case "removeexempt":
-				for(Channel c:config.getChannels()){
-					if(args[1].equals(c.getKey())){
-						c.removeExempt(args[2]);
-						logger.info(USAGE,"{} removed from exempt list of {} by {}!{}@{} ",
-								args[2],args[1],user.getNick(),user.getLogin(),user.getHostmask());
-						rmsg = args[2] + " removed from list";
-					}
-				}
-				break;
-			case "listadmin":
-				for(Channel c:config.getChannels()){
-					if(args[1].equals(c.getKey())){
-						Iterator<String> i = c.getAdmins().iterator();
-						StringBuilder sb = new StringBuilder();
-						while(i.hasNext()){
-							sb.append(i.next());
-							if(i.hasNext()){
-								sb.append(" ,");
-							}
-						}
-						return sb.toString();
-					}
-				}
-			case "listexempt":
-				for(Channel c:config.getChannels()){
-					if(args[1].equals(c.getKey())){
-						Iterator<String> i = c.getExemptMask().iterator();
-						StringBuilder sb = new StringBuilder();
-						while(i.hasNext()){
-							sb.append(i.next());
-							if(i.hasNext()){
-								sb.append(" ,");
-							}
-						}
-						return sb.toString();
-					}
-				}
-			default:
-				return "";
-			}
-			if(rmsg==null){
-				return "Undefined key";
-			}
-			config.write();
-			return "Old config backed up as"+backupName+"\n"+rmsg;
+
+			return resp;
 		}
-		return "";
 	}
-	
+
+	private class RemoveAdminCommand extends Command {
+
+		RemoveAdminCommand() { super("removeadmin", true); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+
+			if(args.length != 3)
+				return Color.color(ColorName.RED)+"ERROR: INCORRECT NUMBER OF PARAMETRES";
+
+			String user = args[2];
+			String channel = args[1];
+
+			for(Channel c:config.getChannels()){
+				if(channel.equals(c.getKey())){
+					c.removeAdmin(user);
+					logger.info(USAGE,"{} removed from admin list of {} by {} ",
+							user,channel,UserUtil.getUserHostmask(ctx.user));
+					return user + " removed from admin list";
+				}
+			}
+
+			return Color.color(ColorName.RED) + "ERROR: NOT AN ADMINISTRATOR, '" + user + "'";
+		}
+	}
+
+	private class ListAdminCommand extends Command {
+
+		ListAdminCommand() { super("listadmin", true); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+
+			if(args.length != 2)
+				return Color.color(ColorName.RED)+"ERROR: INCORRECT NUMBER OF PARAMETRES";
+
+			for(Channel c:config.getChannels()){
+				if(args[1].equals(c.getKey())){
+					Iterator<String> i = c.getAdmins().iterator();
+					StringBuilder sb = new StringBuilder();
+					while(i.hasNext()){
+						sb.append(i.next());
+						if(i.hasNext()){
+							sb.append(" ,");
+						}
+					}
+					return sb.toString();
+				}
+			}
+
+			return "";
+		}
+	}
+
+	private class AddExemptCommand extends Command {
+
+		AddExemptCommand() { super("addexempt", true); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			String resp = "";
+
+			if(args.length != 3)
+				return Color.color(ColorName.RED)+"ERROR: INCORRECT NUMBER OF PARAMETRES";
+
+			String user = args[2];
+			String channel = args[1];
+
+			for(Channel c:config.getChannels()){
+				if(channel.equals(c.getKey())){
+					c.addExempt(user);
+					logger.info(USAGE,"{} added to exempt list of {} by {}",
+							user,channel,UserUtil.getUserHostmask(ctx.user));
+					resp = user + " added to exempt list";
+				}
+			}
+
+			return resp;
+		}
+	}
+
+	private class RemoveExemptCommand extends Command {
+
+		RemoveExemptCommand() { super("removeexempt", true); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+			String resp = "";
+
+			if(args.length != 3)
+				return Color.color(ColorName.RED)+"ERROR: INCORRECT NUMBER OF PARAMETRES";
+
+			String user = args[2];
+			String channel = args[1];
+
+			for(Channel c:config.getChannels()){
+				if(channel.equals(c.getKey())){
+					c.removeExempt(user);
+					logger.info(USAGE,"{} removed from exempt list of {} by {} ",
+							user,channel,UserUtil.getUserHostmask(ctx.user));
+					resp = user + " removed from exempt list";
+				}
+			}
+
+			return resp;
+		}
+	}
+
+	private class ListExemptCommand extends Command {
+
+		ListExemptCommand() { super("listexempt", true); }
+
+		@Override
+		public String run(CommandContext ctx, String args[]) {
+
+			if(args.length != 2)
+				return Color.color(ColorName.RED)+"ERROR: INCORRECT NUMBER OF PARAMETRES";
+
+			for(Channel c:config.getChannels()){
+				if(args[1].equals(c.getKey())){
+					Iterator<String> i = c.getExemptMask().iterator();
+					StringBuilder sb = new StringBuilder();
+					while(i.hasNext()){
+						sb.append(i.next());
+						if(i.hasNext()){
+							sb.append(" ,");
+						}
+					}
+					return sb.toString();
+				}
+			}
+
+			return "";
+		}
+	}
+
 }
+


### PR DESCRIPTION
Reposting [#20](https://github.com/ktllo/inviteBot/pull/20) with some adjustments.

Commands implemented in Console.java are now divded into 'Command' sub-classes which implement 'void main(CommandContext ctx, String args[])'. The output of the command is written to ctx.out, a PrintStream like System.out. The sub-classes may also have associated help presented through their 'void printHelp(PrintStream out)' methods.

In addition to what was in #20, this also makes some commands PM-only (as requested), and implements the 'pong' command.
