### PR TITLE
Add PASS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # Introduction
-This is a simple IRC bot to ask a simple math question before invite user to
+This is a simple IRC bot to ask a simple math question before inviting the user to
 another channel.
 
 #Compile
-You should able to compile using maven, by `mvn compile package`
+You should be able to compile using maven, by `mvn compile package`
 
 #Bot command
-To send command to the bot either
-* Send PM to the bot
-* Send in ANY channel the bot is in, with `escape`(Configurable, default is !) before the command
-* Send in ANY channel the bot is in, begin with bot's nickname
+To send a command to the bot either
+* Send a PM to the bot
+* Send it in ANY channel the bot is in, with `escape`(Configurable, default is !) before the command
+* Send it in ANY channel the bot is in, prefixed with bot's nickname
 
 ##Command list
-* User command
-    * `ping` to see is bot alive
+* User commands
+    * `ping` to see if the bot is alive
     * `resend` to resend the question
     * `version` returns the bot version
     * `info` returns basic bot information
-* Admin command
-    * `invite <user>[ ...]` To invite listed user listed without answering question
+* Admin commands
+    * `invite <user>[ ...]` To invite the given user(s) without answering question
     * `nick <nick>` To change the bot's nick to the given nickname(For GLOBAL admin only)
     * `backup` To backup the configuration file(For GLOBAL admin only)
 
 #Admins
-Global admins are who are IRCOp, `admin` set in the settings.properties.
-Local admins are those set in `<key>.admin` set in settings.properties.
+Global admins are those set in `admin` in settings.properties.
+Local admins are those set in `<key>.admin` in settings.properties.
 
 #Contact us
 You can find us on ##invitebot on freenode

--- a/src/org/leolo/ircbot/inviteBot/Config.java
+++ b/src/org/leolo/ircbot/inviteBot/Config.java
@@ -168,6 +168,9 @@ class Config {
 	@Property( description = "Whether to use secure TLS/SSL connection.", defaultValue = "false" )
 	private boolean ssl;
 
+	@Property( description = "Server Password. you probably won't need this unless you're connecting to a ZNC." )
+	private String servpass;
+
 	@Property( description = "Password which bot will use to authenticate itself on IRC network." )
 	private String password;
 
@@ -251,6 +254,10 @@ class Config {
 
 	public String getNick() {
 		return nick;
+	}
+
+	public String getServerPassword() {
+		return servpass;
 	}
 
 	public String getPassword() {

--- a/src/org/leolo/ircbot/inviteBot/InviteBot.java
+++ b/src/org/leolo/ircbot/inviteBot/InviteBot.java
@@ -176,6 +176,7 @@ public class InviteBot{
 		.setLogin(config.getIdent()) //Login part of hostmask, eg name:login@host
 		.setAutoNickChange(true) //Automatically change nick when the current one is in use
 		.setServer(config.getServer(), config.getPort())
+		.setServerPassword(config.getServerPassword())
 		.addListener(inviter)
 		.setAutoReconnect(true)
 		.addListener(new Console(config,inviter));


### PR DESCRIPTION
I've added support for server passwords (PASS) using `servpass` in settings.properties and made some grammatical changes to the README
